### PR TITLE
Melhoria no try/catch de login

### DIFF
--- a/src/main/java/br/com/techchallenge/foodsys/comandos/login/FiltroAutenticacaoJwt.java
+++ b/src/main/java/br/com/techchallenge/foodsys/comandos/login/FiltroAutenticacaoJwt.java
@@ -6,6 +6,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,6 +20,7 @@ import java.io.IOException;
 public class FiltroAutenticacaoJwt extends OncePerRequestFilter {
 
     private static final String AUTHENTICATION_HEADER = "Bearer ";
+    private static final Logger logger = LoggerFactory.getLogger(FiltroAutenticacaoJwt.class);
 
     private final AutenticaJwtComando jwtService;
     private final AutenticaUsuarioComando userAuthenticationService;
@@ -47,7 +50,7 @@ public class FiltroAutenticacaoJwt extends OncePerRequestFilter {
 
             SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
         } catch (Exception e) {
-            //do nothing
+            logger.warn("Falha ao autenticar token JWT. Token: {}. Erro: {}", token, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
# Problema
Depois que vi a aula de exceções, em que o professor cita que não é uma boa prática manter um catch vazio, eu vi que tinha feito isso 😬 A ideia desse pr é adicionar, ao menos, um log ali pra pegar esses casos.

# Como testar
- Cadastrar um usuário passando também um bearer token inválido na requisição
```
POST /usuarios

{
    "nome" : "Sonia",
    "email": "sonia@teste.com",
    "senha": "12345678",
    "login": "sonia_teste",
    "tipo": 1
}
```
![image](https://github.com/user-attachments/assets/947ab98a-5f77-4acc-a075-500a53d02fe2)

- Cadastrar um usuário sem passar o token

# Resultado

Para o caso em que é passado o token inválido na requisição, precisa ser logado um warn no console como o abaixo:
![image](https://github.com/user-attachments/assets/7d6be13b-464e-4b4c-b682-dda5a43d62ee)
